### PR TITLE
Friendlier time formatting

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source 'https://rubygems.org'
+
+ruby '2.0.0'
+
 gem 'icalendar'
 gem 'chronic_duration'
 gem 'slack-notifier'

--- a/bin/awaybot.rb
+++ b/bin/awaybot.rb
@@ -35,22 +35,28 @@ ics.events.each do |event|
   away_range.each do |date|
     away_duration -= 1 if date.saturday? || date.sunday?
   end
-  look_range = Date.today..(Date.today + cfg["#{type}_announce"]['look_forward_days'])
+  look_range =
+    Date.today..(Date.today + cfg["#{type}_announce"]['look_forward_days'])
   next if (away_range.to_a & look_range.to_a).empty?
   if away_start > Date.today
-    if (away_duration == 1)
-      msg += "#{first_name} is off for the day on #{away_start.strftime('%A')}.\n"
+    if away_duration == 1
+      msg += "#{first_name} is off for the day on" \
+        " #{away_start.strftime('%A, %B %e')}.\n"
     else
       if Date.today.strftime('%A') == away_start.strftime('%A')
         nxt = 'next '
       else
-        nxt = '' 
+        nxt = ''
       end
-      msg += "#{first_name} is off for #{away_duration} days starting #{nxt}#{away_start.strftime('%A')}.\n"
+      msg += "#{first_name} is off for #{away_duration} days starting" \
+        " #{nxt}#{away_start.strftime('%A, %B %e')} until" \
+        " #{away_end.strftime('%A, %B %e')}.\n"
     end
   else
     if away_end - Date.today > 0
-      text_return = ChronicDuration.output((return_day - Date.today) * 60 * 60 * 24, weeks: true, format: :long, units: 2)
+      text_return = ChronicDuration.output(
+        (return_day - Date.today) * 60 * 60 * 24, weeks: true, format: :long, units: 2
+      )
       msg += "#{first_name} is off today, returning in #{text_return}.\n"
     else
       msg += "#{first_name} is off today.\n"
@@ -58,6 +64,7 @@ ics.events.each do |event|
   end
 end
 Kernel.exit(0) unless msg
-msg = "Good morning! Here's who's off for the next #{cfg["#{type}_announce"]['look_forward_days']} days.\n#{msg}"
+msg = "Good morning! Here's who's off for the next" \
+  " #{cfg["#{type}_announce"]['look_forward_days']} days.\n#{msg}"
 slack = Slack::Notifier.new ENV['SLACK_HOOK_URL']
 slack.ping msg


### PR DESCRIPTION
Changed time formatting to match:

`Adam Petrie is off for 6 days starting Friday, August 14 until Friday, August 21.`

instead of:

`Adam Petrie is off for 4 days starting next Thursday.`

as I thought it added useful context to the message.

Also made some lint fixes.